### PR TITLE
Update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Download latest binary from https://github.com/projectdiscovery/nuclei/releases
 nuclei requires **go1.14+** to install successfully. Run the following command to get the repo -
 
 ```sh
-▶ GO111MODULE=auto go get -u -v github.com/projectdiscovery/nuclei/v2/cmd/nuclei
+▶ GO111MODULE=auto go get -u -v github.com/projectdiscovery/nuclei/cmd/nuclei
 ```
 
 ### From Github


### PR DESCRIPTION
In https://github.com/projectdiscovery/nuclei/commit/60005290b1f5f024f9e3e6688297fc03097d3ba1 `v2` was removed from the path. This PR fixes the install instructions